### PR TITLE
Allow Uart Support

### DIFF
--- a/vzlogger/config.json
+++ b/vzlogger/config.json
@@ -18,6 +18,7 @@
   "udev": true,
   "gpio": true,
   "apparmor": false,
+  "uart": true,
   "privileged": ["SYS_RAWIO"],
   "devices": ["/dev/mem"],
   "options": {

--- a/vzlogger/config.json
+++ b/vzlogger/config.json
@@ -5,7 +5,10 @@
   "url": "https://github.com/markussiebert/homeassistant-addon-vzlogger",
   "description": "A tool to read and log measurements of a wide variety of smartmeters and sensors.",
   "arch": ["armhf", "armv7", "amd64"],
-  "map": ["share"],
+  "map": [
+    "share",
+    "config"
+  ],
   "startup": "services",
   "boot": "auto",
   "init": false,


### PR DESCRIPTION
This request contains two minor changes...

1) Fix support for UART USB devices (https://github.com/markussiebert/home-assistant-addons/issues/2) 
2) Mount /config by default, so you can edit your vzlogger.conf with the vscode addon (without advanced configuration)

Grettings,
Tobias 